### PR TITLE
Use `Drop::drop` instead of `Filesystem::destroy` for output

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -215,7 +215,7 @@ impl Filesystem for FS {
     #[instrument(level = "debug", skip(self, _req), fields(dirty = self.dirty.get()))]
     fn destroy(&mut self, _req: &Request) {
         info!("called");
-        self.sync();
+//        self.sync();
         debug!("done syncing");
     }
 
@@ -967,10 +967,7 @@ impl Filesystem for FS {
         reply: ReplyEmpty,
     ) {
         info!("called");
-
-        // TODO 2021-06-16 not really what fsync is meant to mean (it's per inode)
-        self.sync();
-        reply.ok();
+        reply.error(libc::ENOSYS);
     }
 
     // TODO

--- a/src/json.rs
+++ b/src/json.rs
@@ -150,12 +150,12 @@ pub fn load_fs(config: Config, v: Value) -> FS {
     }
     assert_eq!(inodes.len() as u64, next_id);
 
-    FS { inodes, config }
+    FS::new(inodes, config)
 }
 
 #[instrument(level = "info", skip(fs))]
 pub fn save_fs(fs: &FS) {
-    let writer : Box<dyn std::io::Write> = match &fs.config.output {
+    let writer: Box<dyn std::io::Write> = match &fs.config.output {
         Output::Stdout => {
             debug!("outputting on STDOUT");
             Box::new(std::io::stdout())

--- a/tests/output.sh
+++ b/tests/output.sh
@@ -30,11 +30,11 @@ kill -0 $PID >/dev/null 2>&1 && fail process1
 
 # easiest to just test using ffs, but would be cool to get outside validation
 [ -f "$TGT" ] || fail output1
-if [ "$RUNNER_OS" = "Linux" ]
-then
-    echo "ABORTING TEST, currently broken on Linux (see https://github.com/cberner/fuser/issues/153)"
-    exit 0
-fi
+#if [ "$RUNNER_OS" = "Linux" ]
+#then
+#    echo "ABORTING TEST, currently broken on Linux (see https://github.com/cberner/fuser/issues/153)"
+#    exit 0
+#fi
 [ -s "$TGT" ] || fail output2
 cat "$TGT"
 stat "$TGT"
@@ -64,7 +64,7 @@ kill -0 $PID >/dev/null 2>&1 && fail process2
 
 stat "$TGT2"
 [ -f "$TGT2" ] || fail tgt2
-[ -s "$TGT2" ] && fail tgt2_nonemptty
+[ -s "$TGT2" ] && fail tgt2_nonempty
 
 rmdir "$MNT" || fail mount
 rm "$TGT"


### PR DESCRIPTION
Rejiggered the general layout of syncing. Now:

 - `sync` really only happens in `Drop::drop` (but could happen elsewhere)
 - `sync` takes a parameter to indicate if it's the last one (for `Output::Stdout`)
 - if `sync` has happened before, `sync` only actually happens when the FS is dirty