### PR TITLE
Implement `setattr`

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -11,6 +11,9 @@ cd tests
 
 LOG=$(mktemp -d)
 
+RUST_LOG="ffs=debug"
+export RUST_LOG
+
 # spawn 'em all in parallel
 for test in *.sh
 do

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -46,5 +46,13 @@ do
 done
 
 printf "$((TOTAL - FAILED))/$((TOTAL)) tests passed\n"
+
+echo "CHOWN macos:"
+printf "<<<<<<<<<< STDOUT\n"
+cat $LOG/chown.out
+printf "<<<<<<<<<< STDERR\n"
+cat $LOG/chown.err
+
+
 rm -r $LOG
 [ $FAILED -eq 0 ] || exit 1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -28,14 +28,14 @@ MNT=$(mktemp -d)
 RUST_LOG="ffs=debug" ffs -d "$MNT" ../json/object.json &
 PID=$!
 sleep 2
-chown :nobody "$MNT"/name 2>$ERR >&2 && fail "chgrp1: $(cat $ERR)"
+chown -v :nobody "$MNT"/name 2>$ERR >&2 && fail "chgrp1: $(cat $ERR)"
 [ -s "$ERR" ] || fail "chgrp1 error: $(cat $ERR)"
 groups
 ls -l "$MNT"/name
 echo $(groups | cut -d' ' -f 1)
-chown :$(groups | cut -d' ' -f 1) "$MNT"/name 2>$ERR >&2 || fail "chgrp2: $(cat $ERR)"
+chown -v :$(groups | cut -d' ' -f 1) "$MNT"/name 2>$ERR >&2 || fail "chgrp2: $(cat $ERR)"
 [ -s "$ERR" ] && fail "chgrp2 error: $(cat $ERR)"
-chown $(whoami) "$MNT"/name 2>$ERR >&2 || fail chown
+chown -v $(whoami) "$MNT"/name 2>$ERR >&2 || fail chown
 [ -s "$ERR" ] && fail "chown error: $(cat $ERR)"
 umount "$MNT" || fail unmount1    
 sleep 1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -11,6 +11,38 @@ cd tests
 
 LOG=$(mktemp -d)
 
+fail() {
+    echo FAILED: $1
+    if [ "$MNT" ]
+    then
+        cd
+        umount "$MNT"
+        rmdir "$MNT"
+        rm "$ERR"
+    fi
+    exit 1
+}
+
+ERR=$(mktemp)
+MNT=$(mktemp -d)
+RUST_LOG="ffs=debug" ffs -d "$MNT" ../json/object.json &
+PID=$!
+sleep 2
+chown :nobody "$MNT"/name 2>$ERR >&2 && fail "chgrp1: $(cat $ERR)"
+[ -s "$ERR" ] || fail "chgrp1 error: $(cat $ERR)"
+groups
+ls -l "$MNT"/name
+echo $(groups | cut -d' ' -f 1)
+chown :$(groups | cut -d' ' -f 1) "$MNT"/name 2>$ERR >&2 || fail "chgrp2: $(cat $ERR)"
+[ -s "$ERR" ] && fail "chgrp2 error: $(cat $ERR)"
+chown $(whoami) "$MNT"/name 2>$ERR >&2 || fail chown
+[ -s "$ERR" ] && fail "chown error: $(cat $ERR)"
+umount "$MNT" || fail unmount1    
+sleep 1
+kill -0 $PID >/dev/null 2>&1 && fail process1
+rmdir "$MNT"
+rm "$ERR"
+
 # spawn 'em all in parallel
 for test in *.sh
 do
@@ -46,13 +78,6 @@ do
 done
 
 printf "$((TOTAL - FAILED))/$((TOTAL)) tests passed\n"
-
-echo "CHOWN macos:"
-printf "<<<<<<<<<< STDOUT\n"
-cat $LOG/chown.out
-printf "<<<<<<<<<< STDERR\n"
-cat $LOG/chown.err
-
 
 rm -r $LOG
 [ $FAILED -eq 0 ] || exit 1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -11,15 +11,12 @@ cd tests
 
 LOG=$(mktemp -d)
 
-RUST_LOG="ffs=debug"
-export RUST_LOG
-
 # spawn 'em all in parallel
 for test in *.sh
 do
     tname="$(basename ${test%*.sh})"
     printf "========== STARTING TEST: $tname\n"
-    (./${test} >$LOG/$tname.out 2>$LOG/$tname.nerr; echo $?>$LOG/$tname.ec) &
+    (RUST_LOG="ffs=debug" ./${test} >$LOG/$tname.out 2>$LOG/$tname.nerr; echo $?>$LOG/$tname.ec) &
     : $((TOTAL += 1))
 
     # don't slam 'em

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,37 +7,6 @@ FAILED=0
 ERRORS=""
 cd tests
 
-fail() {
-    echo FAILED: $1
-    if [ "$MNT" ]
-    then
-        cd
-        umount "$MNT"
-        rmdir "$MNT"
-        rm "$ERR"
-    fi
-    exit 1
-}
-
-ERR=$(mktemp)
-MNT=$(mktemp -d)
-RUST_LOG="ffs=debug" ffs -d "$MNT" ../json/object.json &
-PID=$!
-sleep 2
-chown -v :nobody "$MNT"/name 2>$ERR >&2 && fail "chgrp1: $(cat $ERR)"
-[ -s "$ERR" ] || fail "chgrp1 error: $(cat $ERR)"
-groups
-ls -l "$MNT"/name
-echo $(groups | cut -d' ' -f 1)
-chown -v :$(groups | cut -d' ' -f 1) "$MNT"/name 2>$ERR >&2 || echo "chgrp2: $(cat $ERR)"
-chown -v $(whoami) "$MNT"/name 2>$ERR >&2 || echo "chown: $(cat $ERR)"
-umount "$MNT" || fail unmount1    
-sleep 1
-kill -0 $PID >/dev/null 2>&1 && fail process1
-rmdir "$MNT"
-rm "$ERR"
-
-
 LOG=$(mktemp -d)
 
 # spawn 'em all in parallel

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use fuser::FileType;
 use std::path::PathBuf;
 
 use super::format::Format;
@@ -42,6 +43,15 @@ impl Config {
             .replace(";", "semi")
             .replace("=", "equal")
             .replace(" ", "space")
+    }
+
+    /// Determines the default mode of a file
+    pub fn mode(&self, kind: FileType) -> u16 {
+        if kind == FileType::Directory {
+            self.dirmode
+        } else {
+            self.filemode
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,6 @@ use super::format::Format;
 pub struct Config {
     pub input_format: Format,
     pub output_format: Format,
-    pub timestamp: std::time::SystemTime,
     pub uid: u32,
     pub gid: u32,
     pub filemode: u16,
@@ -60,7 +59,6 @@ impl Default for Config {
         Config {
             input_format: Format::Json,
             output_format: Format::Json,
-            timestamp: std::time::SystemTime::now(),
             uid: 501,
             gid: 501,
             filemode: 0o644,

--- a/src/format.rs
+++ b/src/format.rs
@@ -282,11 +282,7 @@ where
             }
         };
 
-        inodes[inum as usize] = Some(Inode {
-            parent,
-            inum,
-            entry,
-        });
+        inodes[inum as usize] = Some(Inode::new(parent, inum, entry, config));
     }
     assert_eq!(inodes.len() as u64, next_id);
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -466,7 +466,8 @@ impl Filesystem for FS {
         let now = SystemTime::now();
         let mut set_time = false;
         if let Some(atime) = atime {
-            if self.check_access(req) && atime != TimeOrNow::Now {
+            info!("setting atime");
+            if !self.check_access(req) {
                 reply.error(libc::EPERM);
                 return;
             }
@@ -486,7 +487,9 @@ impl Filesystem for FS {
         }
 
         if let Some(mtime) = mtime {
-            if self.check_access(req) && mtime != TimeOrNow::Now {
+            info!("setting mtime");
+
+            if !self.check_access(req) {
                 reply.error(libc::EPERM);
                 return;
             }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1580,7 +1580,7 @@ fn groups_for(uid: u32) -> Vec<u32> {
         libc::getgrouplist(name, basegid, std::ptr::null_mut(), &mut ngroups);
         let mut groups = vec![0; ngroups as usize];
         let res = libc::getgrouplist(name, basegid, groups.as_mut_ptr(), &mut ngroups);
-        assert_eq!(res, 0);
+        assert_eq!(res, ngroups);
         groups
     }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1554,7 +1554,7 @@ fn groups_for(uid: u32) -> Vec<u32> {
     unsafe {
         let passwd = libc::getpwuid(uid);
         let name = (*passwd).pw_name;
-        let basegid = (*passwd).pw_gid as i32;
+        let basegid = (*passwd).pw_gid;
 
         // get the number of groups
         let mut ngroups = 0;
@@ -1563,5 +1563,6 @@ fn groups_for(uid: u32) -> Vec<u32> {
         let mut groups = vec![0; ngroups as usize];
         let res = libc::getgrouplist(name, basegid, groups.as_mut_ptr(), &mut ngroups);
         assert_eq!(res, 0);
+        groups
     }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1544,7 +1544,6 @@ fn groups_for(uid: u32) -> Vec<u32> {
 
         if ngroups == 0 {
             // BUG 2021-06-23 weird behavior on macos... :/
-            warn!("macOS getgrouplist bug is present");
             ngroups = 50;
         }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -50,6 +50,7 @@ pub struct Inode {
     pub mode: u16,
     /// The actual file contents.
     pub entry: Entry,
+    // TODO 2021-06-21 track timestamp info here, add support in setattr?
 }
 
 /// File contents. Either a `File` containing bytes or a `Directory`, mapping

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -13,7 +13,7 @@ use fuser::{
 #[cfg(target_os = "macos")]
 use fuser::ReplyXTimes;
 
-use tracing::{debug, info, instrument, trace, warn};
+use tracing::{info, instrument, trace, warn};
 
 use super::config::{Config, Output};
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -374,7 +374,7 @@ impl Filesystem for FS {
 
         reply.attr(&TTL, &self.attr(file));
     }
-
+    
     #[instrument(
         level = "debug",
         skip(

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -505,7 +505,6 @@ impl Filesystem for FS {
                     Entry::File(contents) => {
                         contents.resize(size as usize, 0);
                         reply.attr(&TTL, &inode.attr());
-                        return;
                     }
                     Entry::Directory(..) => {
                         reply.error(libc::EISDIR);
@@ -517,6 +516,9 @@ impl Filesystem for FS {
                     return;
                 }
             };
+
+            self.dirty.set(true);
+            return;
         }
 
         let now = SystemTime::now();

--- a/tests/chmod.sh
+++ b/tests/chmod.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+fail() {
+    echo FAILED: $1
+    if [ "$MNT" ]
+    then
+        cd
+        umount "$MNT"
+        rmdir "$MNT"
+        rm "$TGT"
+        rm "$TGT2"
+    fi
+    exit 1
+}
+
+MNT=$(mktemp -d)
+TGT=$(mktemp)
+TGT2=$(mktemp)
+
+ffs "$MNT" ../json/object.json >"$TGT" &
+PID=$!
+sleep 2
+echo 'echo hi' >"$MNT"/script
+chmod +x "$MNT"/script
+[ "$($MNT/script)" = "hi" ] || fail exec
+umount "$MNT" || fail unmount1    
+sleep 1
+kill -0 $PID >/dev/null 2>&1 && fail process1
+
+# easiest to just test using ffs, but would be cool to get outside validation
+[ -f "$TGT" ] || fail output1
+[ -s "$TGT" ] || fail output2
+grep -e echo "$TGT" >/dev/null 2>&1 || fail grep
+ffs --no-output --source json "$MNT" "$TGT" >"$TGT2" &
+PID=$!
+sleep 2
+
+case $(ls "$MNT") in
+    (eyes*fingernails*human*name*script) ;;
+    (*) fail ls;;
+esac
+
+[ "$(cat $MNT/script)" = "echo hi" ] || fail contents
+
+umount "$MNT" || fail unmount2
+sleep 1
+kill -0 $PID >/dev/null 2>&1 && fail process2
+
+[ -f "$TGT2" ] || fail tgt2
+[ -s "$TGT2" ] && fail tgt2_nonempty
+
+rmdir "$MNT" || fail mount
+rm "$TGT"
+rm "$TGT2"

--- a/tests/chown.sh
+++ b/tests/chown.sh
@@ -18,10 +18,10 @@ ERR=$(mktemp)
 ffs --no-output "$MNT" ../json/object.json &
 PID=$!
 sleep 2
-groups
-cat /etc/group
 chown :nobody "$MNT"/name 2>$ERR >&2 && fail "chgrp1: $(cat $ERR)"
 [ -s "$ERR" ] || fail "chgrp1 error: $(cat $ERR)"
+groups
+ls -l "$MNT"/name
 chown :$(groups | cut -d' ' -f 1) "$MNT"/name 2>$ERR >&2 || fail "chgrp2: $(cat $ERR)"
 [ -s "$ERR" ] && fail "chgrp2 error: $(cat $ERR)"
 chown $(whoami) "$MNT"/name 2>$ERR >&2 || fail chown

--- a/tests/chown.sh
+++ b/tests/chown.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+fail() {
+    echo FAILED: $1
+    if [ "$MNT" ]
+    then
+        cd
+        umount "$MNT"
+        rmdir "$MNT"
+        rm "$ERR"
+    fi
+    exit 1
+}
+
+MNT=$(mktemp -d)
+ERR=$(mktemp)
+
+ffs --no-output "$MNT" ../json/object.json &
+PID=$!
+sleep 2
+chown :wheel "$MNT"/name 2>$ERR >&2 && fail "chgrp1: $(cat $ERR)"
+[ -s "$ERR" ] || fail "chgrp1 error: $(cat $ERR)"
+chown :$(groups | cut -d' ' -f 1) "$MNT"/name 2>$ERR >&2 || fail "chgrp2: $(cat $ERR)"
+[ -s "$ERR" ] && fail "chgrp2 error: $(cat $ERR)"
+chown $(whoami) "$MNT"/name 2>$ERR >&2 || fail chown
+[ -s "$ERR" ] && fail "chown error: $(cat $ERR)"
+umount "$MNT" || fail unmount1    
+sleep 1
+kill -0 $PID >/dev/null 2>&1 && fail process1
+
+rmdir "$MNT" || fail mount
+rm "$ERR"
+

--- a/tests/chown.sh
+++ b/tests/chown.sh
@@ -15,13 +15,14 @@ fail() {
 MNT=$(mktemp -d)
 ERR=$(mktemp)
 
-ffs -d --no-output "$MNT" ../json/object.json &
+RUST_LOG="ffs=debug" ffs -d --no-output "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 chown :nobody "$MNT"/name 2>$ERR >&2 && fail "chgrp1: $(cat $ERR)"
 [ -s "$ERR" ] || fail "chgrp1 error: $(cat $ERR)"
 groups
 ls -l "$MNT"/name
+echo $(groups | cut -d' ' -f 1)
 chown :$(groups | cut -d' ' -f 1) "$MNT"/name 2>$ERR >&2 || fail "chgrp2: $(cat $ERR)"
 [ -s "$ERR" ] && fail "chgrp2 error: $(cat $ERR)"
 chown $(whoami) "$MNT"/name 2>$ERR >&2 || fail chown

--- a/tests/chown.sh
+++ b/tests/chown.sh
@@ -15,7 +15,7 @@ fail() {
 MNT=$(mktemp -d)
 ERR=$(mktemp)
 
-ffs --no-output "$MNT" ../json/object.json &
+ffs -d --no-output "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 chown :nobody "$MNT"/name 2>$ERR >&2 && fail "chgrp1: $(cat $ERR)"

--- a/tests/chown.sh
+++ b/tests/chown.sh
@@ -18,7 +18,9 @@ ERR=$(mktemp)
 ffs --no-output "$MNT" ../json/object.json &
 PID=$!
 sleep 2
-chown :wheel "$MNT"/name 2>$ERR >&2 && fail "chgrp1: $(cat $ERR)"
+groups
+cat /etc/group
+chown :nobody "$MNT"/name 2>$ERR >&2 && fail "chgrp1: $(cat $ERR)"
 [ -s "$ERR" ] || fail "chgrp1 error: $(cat $ERR)"
 chown :$(groups | cut -d' ' -f 1) "$MNT"/name 2>$ERR >&2 || fail "chgrp2: $(cat $ERR)"
 [ -s "$ERR" ] && fail "chgrp2 error: $(cat $ERR)"

--- a/tests/mode.sh
+++ b/tests/mode.sh
@@ -21,7 +21,6 @@ sleep 2
 cd "$MNT"
 ls -l eyes | grep -e 'rw-rw-rw-' >/dev/null 2>&1 || fail file1
 mkdir pockets
-ls -ld pockets
 ls -ld pockets | grep -e 'rwxr-xr-x' >/dev/null 2>&1 || fail dir1
 cd - >/dev/null 2>&1
 umount "$MNT" || fail unmount1

--- a/tests/mode.sh
+++ b/tests/mode.sh
@@ -13,25 +13,29 @@ fail() {
 
 MNT=$(mktemp -d)
 
+umask 022
+
 ffs --mode 666 "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 cd "$MNT"
 ls -l eyes | grep -e 'rw-rw-rw-' >/dev/null 2>&1 || fail file1
 mkdir pockets
-ls -ld pockets | grep -e 'rwxrwxrwx' >/dev/null 2>&1 || fail dir1
+ls -ld pockets
+ls -ld pockets | grep -e 'rwxr-xr-x' >/dev/null 2>&1 || fail dir1
 cd - >/dev/null 2>&1
 umount "$MNT" || fail unmount1
 sleep 1
 kill -0 $PID >/dev/null 2>&1 && fail process1
 
+umask 077
 ffs --mode 666 --dirmode 700 "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 cd "$MNT"
 ls -l eyes | grep -e 'rw-rw-rw-' >/dev/null 2>&1 || fail file2
 mkdir pockets
-ls -ld pockets | grep -e 'rwx------' >/dev/null 2>&1 || fail dir2
+ls -ld pockets | grep -e 'rwx----' >/dev/null 2>&1 || fail dir2
 cd - >/dev/null 2>&1
 umount "$MNT" || fail unmount2
 sleep 1

--- a/tests/touch.sh
+++ b/tests/touch.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+fail() {
+    echo FAILED: $1
+    if [ "$MNT" ]
+    then
+        cd
+        umount "$MNT"
+        rmdir "$MNT"
+        rm "$ERR"
+    fi
+    exit 1
+}
+
+MNT=$(mktemp -d)
+ERR=$(mktemp)
+
+ffs --no-output "$MNT" ../json/object.json &
+PID=$!
+sleep 2
+touch "$MNT"/name 2>$ERR >&2 || fail touch
+[ -s "$ERR" ] && { cat "$ERR"; fail error ; }
+umount "$MNT" || fail unmount1    
+sleep 1
+kill -0 $PID >/dev/null 2>&1 && fail process1
+
+rmdir "$MNT" || fail mount
+rm "$ERR"
+

--- a/tests/touch.sh
+++ b/tests/touch.sh
@@ -18,7 +18,7 @@ ERR=$(mktemp)
 ffs --no-output "$MNT" ../json/object.json &
 PID=$!
 sleep 2
-touch "$MNT"/name 2>$ERR >&2 || fail touch
+touch "$MNT"/name 2>$ERR >&2 || { cat "$ERR"; fail touch; }
 [ -s "$ERR" ] && { cat "$ERR"; fail error ; }
 umount "$MNT" || fail unmount1    
 sleep 1

--- a/tests/truncate.sh
+++ b/tests/truncate.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+fail() {
+    echo FAILED: $1
+    if [ "$MNT" ]
+    then
+        cd
+        umount "$MNT"
+        rmdir "$MNT"
+        rm "$TGT"
+        rm "$TGT2"
+        rm "$ERR"
+    fi
+    exit 1
+}
+
+MNT=$(mktemp -d)
+TGT=$(mktemp)
+TGT2=$(mktemp)
+ERR=$(mktemp)
+
+ffs "$MNT" ../json/object.json >"$TGT" &
+PID=$!
+sleep 2
+echo 'Mikey Indiana' >"$MNT"/name 2>"$ERR"
+[ -s "$ERR" ] && fail non-empty error
+umount "$MNT" || fail unmount1    
+sleep 1
+kill -0 $PID >/dev/null 2>&1 && fail process1
+
+# easiest to just test using ffs, but would be cool to get outside validation
+[ -f "$TGT" ] || fail output1
+[ -s "$TGT" ] || fail output2
+grep -e Indiana "$TGT" >/dev/null 2>&1 || fail grep
+ffs --no-output --source json "$MNT" "$TGT" >"$TGT2" &
+PID=$!
+sleep 2
+
+case $(ls "$MNT") in
+    (eyes*fingernails*human*name) ;;
+    (*) fail ls;;
+esac
+
+[ "$(cat $MNT/name)" = "Mikey Indiana" ] || fail contents
+
+umount "$MNT" || fail unmount2
+sleep 1
+kill -0 $PID >/dev/null 2>&1 && fail process2
+
+[ -f "$TGT2" ] || fail tgt2
+[ -s "$TGT2" ] && fail tgt2_nonempty
+
+rmdir "$MNT" || fail mount
+rm "$TGT"
+rm "$TGT2"
+rm "$ERR"


### PR DESCRIPTION
The `setattr` interface implements `chmod`, `chown`, `truncate`, and some timing related things.

It's not clear I've covered _every_ base, but it certainly seems to allow for common use cases in bash without any error messages.