### PR TITLE
Better mount control

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,25 @@ pub struct Config {
     pub base64: base64::Config,
     pub try_decode_base64: bool,
     pub read_only: bool,
+    pub input: Input,
     pub output: Output,
+    pub mount: Option<PathBuf>,
+    pub cleanup_mount: bool,
+}
+
+#[derive(Debug)]
+pub enum Input {
+    Stdin,
+    File(PathBuf),
+}
+
+impl std::fmt::Display for Input {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            Input::Stdin => write!(f, "<stdin>"),
+            Input::File(file) => write!(f, "{}", file.display()),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -68,7 +86,10 @@ impl Default for Config {
             base64: base64::STANDARD,
             try_decode_base64: false,
             read_only: false,
+            input: Input::Stdin,
             output: Output::Stdout,
+            mount: None,
+            cleanup_mount: false,
         }
     }
 }

--- a/tests/bad_root.sh
+++ b/tests/bad_root.sh
@@ -15,7 +15,7 @@ MNT=$(mktemp -d)
 OUT=$(mktemp)
 MSG=$(mktemp)
 
-ffs "$MNT" ../json/null.json >"$OUT" 2>"$MSG" &
+ffs -m "$MNT" ../json/null.json >"$OUT" 2>"$MSG" &
 PID=$!
 sleep 1
 kill -0 $PID >/dev/null 2>&1 && fail process

--- a/tests/bad_root_stdin.sh
+++ b/tests/bad_root_stdin.sh
@@ -15,7 +15,7 @@ MNT=$(mktemp -d)
 OUT=$(mktemp)
 MSG=$(mktemp)
 
-echo \"just a string\" | ffs "$MNT" >"$OUT" 2>"$MSG" &
+echo \"just a string\" | ffs -m "$MNT" >"$OUT" 2>"$MSG" &
 PID=$!
 sleep 1
 kill -0 $PID >/dev/null 2>&1 && fail process

--- a/tests/basic_list.sh
+++ b/tests/basic_list.sh
@@ -13,7 +13,7 @@ fail() {
 
 MNT=$(mktemp -d)
 
-ffs "$MNT" ../json/list.json &
+ffs -m "$MNT" ../json/list.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/basic_object.sh
+++ b/tests/basic_object.sh
@@ -13,7 +13,7 @@ fail() {
 
 MNT=$(mktemp -d)
 
-ffs "$MNT" ../json/object.json &
+ffs -m "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/basic_object_exact.sh
+++ b/tests/basic_object_exact.sh
@@ -22,7 +22,7 @@ printf "10"                >"${EXP}/fingernails"
 printf "true"              >"${EXP}/human"
 printf ""                  >"${EXP}/problems"
 
-ffs "$MNT" ../json/object_null.json &
+ffs -m "$MNT" ../json/object_null.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/basic_object_newline.sh
+++ b/tests/basic_object_newline.sh
@@ -22,7 +22,7 @@ printf "10\n"                >"${EXP}/fingernails"
 printf "true\n"              >"${EXP}/human"
 printf ""                    >"${EXP}/problems"
 
-ffs --newline "$MNT" ../json/object_null.json &
+ffs --newline -m "$MNT" ../json/object_null.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/basic_object_stdin.sh
+++ b/tests/basic_object_stdin.sh
@@ -13,7 +13,7 @@ fail() {
 
 MNT=$(mktemp -d)
 
-cat ../json/object.json | ffs "$MNT" &
+cat ../json/object.json | ffs -m "$MNT" &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/basic_toml.sh
+++ b/tests/basic_toml.sh
@@ -13,7 +13,7 @@ fail() {
 
 MNT=$(mktemp -d)
 
-ffs "$MNT" ../toml/eg.toml &
+ffs -m "$MNT" ../toml/eg.toml &
 PID=$!
 sleep 2
 case $(ls "$MNT") in

--- a/tests/binary.sh
+++ b/tests/binary.sh
@@ -30,7 +30,7 @@ MNT=$(mktemp -d)
 TGT=$(mktemp)
 TGT2=$(mktemp)
 
-ffs "$MNT" ../json/object.json >"$TGT" &
+ffs -m "$MNT" ../json/object.json >"$TGT" &
 PID=$!
 sleep 2
 cp ../binary/twitter.ico "$MNT"/favicon
@@ -42,7 +42,7 @@ kill -0 $PID >/dev/null 2>&1 && fail process1
 [ -f "$TGT" ] || fail output1
 [ -s "$TGT" ] || fail output2
 grep favicon "$TGT" >/dev/null 2>&1 || fail text
-ffs --no-output "$MNT" "$TGT" >"$TGT2" &
+ffs --no-output -m "$MNT" "$TGT" >"$TGT2" &
 PID=$!
 sleep 2
 

--- a/tests/chmod.sh
+++ b/tests/chmod.sh
@@ -17,7 +17,7 @@ MNT=$(mktemp -d)
 TGT=$(mktemp)
 TGT2=$(mktemp)
 
-ffs "$MNT" ../json/object.json >"$TGT" &
+ffs -m "$MNT" ../json/object.json >"$TGT" &
 PID=$!
 sleep 2
 echo 'echo hi' >"$MNT"/script
@@ -31,7 +31,7 @@ kill -0 $PID >/dev/null 2>&1 && fail process1
 [ -f "$TGT" ] || fail output1
 [ -s "$TGT" ] || fail output2
 grep -e echo "$TGT" >/dev/null 2>&1 || fail grep
-ffs --no-output --source json "$MNT" "$TGT" >"$TGT2" &
+ffs --no-output --source json -m "$MNT" "$TGT" >"$TGT2" &
 PID=$!
 sleep 2
 

--- a/tests/chown.sh
+++ b/tests/chown.sh
@@ -15,14 +15,11 @@ fail() {
 MNT=$(mktemp -d)
 ERR=$(mktemp)
 
-RUST_LOG="ffs=debug" ffs -d --no-output "$MNT" ../json/object.json &
+ffs -d --no-output -m "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 chown :nobody "$MNT"/name 2>$ERR >&2 && fail "chgrp1: $(cat $ERR)"
 [ -s "$ERR" ] || fail "chgrp1 error: $(cat $ERR)"
-groups
-ls -l "$MNT"/name
-echo $(groups | cut -d' ' -f 1)
 chown :$(groups | cut -d' ' -f 1) "$MNT"/name 2>$ERR >&2 || fail "chgrp2: $(cat $ERR)"
 [ -s "$ERR" ] && fail "chgrp2 error: $(cat $ERR)"
 chown $(whoami) "$MNT"/name 2>$ERR >&2 || fail chown

--- a/tests/exact_cleanup.sh
+++ b/tests/exact_cleanup.sh
@@ -25,7 +25,7 @@ printf "true"              >"${EXP}/human"
 printf "hi\n"              >"${EXP}/greeting"
 printf "bye"               >"${EXP}/farewell"
 
-ffs -o "$JSON" "$MNT" ../json/object.json &
+ffs -o "$JSON" -m "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 echo hi >"$MNT"/greeting
@@ -35,7 +35,7 @@ sleep 1
 kill -0 $PID >/dev/null 2>&1 && fail process
 
 # remount w/o --newline, confirm that they're not there (except for greeting)
-ffs "$MNT" "$JSON" &
+ffs -m "$MNT" "$JSON" &
 sleep 2
 case $(ls "$MNT") in
     (eyes*farewell*fingernails*greeting*human*name) ;;

--- a/tests/file_creation.sh
+++ b/tests/file_creation.sh
@@ -13,7 +13,7 @@ fail() {
 
 MNT=$(mktemp -d)
 
-ffs "$MNT" ../json/object.json &
+ffs -m "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/force_uid_gid.sh
+++ b/tests/force_uid_gid.sh
@@ -13,7 +13,7 @@ fail() {
 
 MNT=$(mktemp -d)
 
-ffs --uid $(id -u root) --gid $(id -g root) "$MNT" ../json/object.json &
+ffs --uid $(id -u root) --gid $(id -g root) -m "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 ls -l "$MNT" | grep root >/dev/null 2>&1 || fail user

--- a/tests/infer_mount.sh
+++ b/tests/infer_mount.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+fail() {
+    echo FAILED: $1
+    if [ "$MNT" ]
+    then
+        cd
+        umount "$TMP"/object
+        rm -r "$TMP"
+    fi
+    exit 1
+}
+
+TMP=$(mktemp -d)
+
+cp ../json/object.json "$TMP"
+cd "$TMP"
+ffs object.json &
+PID=$!
+sleep 2
+[ -d "object" ] || fail mountdir
+case $(ls object) in
+    (eyes*fingernails*human*name) ;;
+    (*) fail ls;;
+esac
+[ "$(cat object/name)" = "Michael Greenberg" ] || fail name
+[ "$(cat object/eyes)" -eq 2 ] || fail eyes
+[ "$(cat object/fingernails)" -eq 10 ] || fail fingernails
+[ "$(cat object/human)" = "true" ] || fail human
+umount object || fail unmount
+sleep 1
+
+kill -0 $PID >/dev/null 2>&1 && fail process
+
+[ -d "object" ] && fail cleanup
+cd -
+rm -r "$TMP"

--- a/tests/json_to_toml.sh
+++ b/tests/json_to_toml.sh
@@ -15,7 +15,7 @@ fail() {
 MNT=$(mktemp -d)
 TGT=$(mktemp)
 
-ffs --source json --target toml -o "$TGT" "$MNT" ../json/single.json &
+ffs --source json --target toml -o "$TGT" -m "$MNT" ../json/single.json &
 PID=$!
 sleep 2
 umount "$MNT" || fail unmount1    

--- a/tests/mode.sh
+++ b/tests/mode.sh
@@ -15,7 +15,7 @@ MNT=$(mktemp -d)
 
 umask 022
 
-ffs --mode 666 "$MNT" ../json/object.json &
+ffs --mode 666 -m "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 cd "$MNT"
@@ -28,7 +28,7 @@ sleep 1
 kill -0 $PID >/dev/null 2>&1 && fail process1
 
 umask 077
-ffs --mode 666 --dirmode 700 "$MNT" ../json/object.json &
+ffs --mode 666 --dirmode 700 -m "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/newline_cleanup.sh
+++ b/tests/newline_cleanup.sh
@@ -25,7 +25,7 @@ printf "true"              >"${EXP}/human"
 printf "hi"                >"${EXP}/greeting"
 printf "bye"               >"${EXP}/farewell"
 
-ffs --newline -o "$JSON" "$MNT" ../json/object.json &
+ffs --newline -o "$JSON" -m "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 echo hi >"$MNT"/greeting
@@ -35,7 +35,7 @@ sleep 1
 kill -0 $PID >/dev/null 2>&1 && fail process
 
 # remount w/o --newline, confirm that they're not there
-ffs "$MNT" "$JSON" &
+ffs -m "$MNT" "$JSON" &
 sleep 2
 case $(ls "$MNT") in
     (eyes*farewell*fingernails*greeting*human*name) ;;

--- a/tests/nlink.sh
+++ b/tests/nlink.sh
@@ -25,7 +25,7 @@ fi
 
 MNT=$(mktemp -d)
 
-ffs "$MNT" ../json/nlink.json &
+ffs -m "$MNT" ../json/nlink.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/output.sh
+++ b/tests/output.sh
@@ -17,7 +17,7 @@ MNT=$(mktemp -d)
 TGT=$(mktemp)
 TGT2=$(mktemp)
 
-ffs "$MNT" ../json/object.json >"$TGT" &
+ffs -m "$MNT" ../json/object.json >"$TGT" &
 PID=$!
 sleep 2
 mkdir "$MNT"/pockets
@@ -38,7 +38,7 @@ kill -0 $PID >/dev/null 2>&1 && fail process1
 [ -s "$TGT" ] || fail output2
 cat "$TGT"
 stat "$TGT"
-ffs --no-output "$MNT" "$TGT" >"$TGT2" &
+ffs --no-output -m "$MNT" "$TGT" >"$TGT2" &
 PID=$!
 sleep 2
 

--- a/tests/override_infer.sh
+++ b/tests/override_infer.sh
@@ -18,7 +18,7 @@ TGT=$(mktemp)
 
 cp ../toml/single.toml "$SRC"
 
-ffs --source toml --target json -o "$TGT" "$MNT" "$SRC" &
+ffs --source toml --target json -o "$TGT" -m "$MNT" "$SRC" &
 PID=$!
 sleep 2
 umount "$MNT" || fail unmount1    

--- a/tests/pad_list.sh
+++ b/tests/pad_list.sh
@@ -13,7 +13,7 @@ fail() {
 
 MNT=$(mktemp -d)
 
-ffs "$MNT" ../json/list2.json &
+ffs -m "$MNT" ../json/list2.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/quiet_inplace.sh
+++ b/tests/quiet_inplace.sh
@@ -16,7 +16,7 @@ JSON=$(mktemp)
 
 cp ../json/object.json "$JSON"
 
-ffs -qi "$MNT" "$JSON" &
+ffs -qi -m "$MNT" "$JSON" &
 PID=$!
 sleep 2
 echo hi >"$MNT"/greeting
@@ -27,7 +27,7 @@ kill -0 $PID >/dev/null 2>&1 && fail process1
 
 diff ../json/object.json "$JSON" >/dev/null && fail same
 
-ffs --readonly "$MNT" "$JSON" &
+ffs --readonly -m "$MNT" "$JSON" &
 PID=$!
 sleep 2
 [ "$(cat $MNT/greeting)" = "hi" ] || fail updated

--- a/tests/read_only.sh
+++ b/tests/read_only.sh
@@ -13,7 +13,7 @@ fail() {
 
 MNT=$(mktemp -d)
 
-ffs --readonly "$MNT" ../json/object.json &
+ffs --readonly -m "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/rename.sh
+++ b/tests/rename.sh
@@ -13,7 +13,7 @@ fail() {
 
 MNT=$(mktemp -d)
 
-ffs "$MNT" ../json/object.json &
+ffs -m "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/rename_object.sh
+++ b/tests/rename_object.sh
@@ -13,7 +13,7 @@ fail() {
 
 MNT=$(mktemp -d)
 
-ffs "$MNT" ../json/obj_rename.json &
+ffs -m "$MNT" ../json/obj_rename.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/rmdir.sh
+++ b/tests/rmdir.sh
@@ -13,7 +13,7 @@ fail() {
 
 MNT=$(mktemp -d)
 
-ffs "$MNT" ../json/object.json &
+ffs -m "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/toml_output.sh
+++ b/tests/toml_output.sh
@@ -20,7 +20,7 @@ TOML="$TOML".toml
 
 cp ../toml/eg.toml "$TOML"
 
-ffs -i "$MNT" "$TOML" &
+ffs -i -m "$MNT" "$TOML" &
 PID=$!
 sleep 2
 case $(ls "$MNT") in
@@ -35,7 +35,7 @@ umount "$MNT" || fail unmount1
 sleep 1
 kill -0 $PID >/dev/null 2>&1 && fail process1
 
-ffs --readonly --no-output "$MNT" "$TOML" &
+ffs --readonly --no-output -m "$MNT" "$TOML" &
 PID=$!
 sleep 2
 [ "$(cat $MNT/clients/hosts/0)" = "alpha" ] || fail hosts0

--- a/tests/toml_to_json.sh
+++ b/tests/toml_to_json.sh
@@ -15,7 +15,7 @@ fail() {
 MNT=$(mktemp -d)
 TGT=$(mktemp)
 
-ffs --source toml --target json -o "$TGT" "$MNT" ../toml/single.toml &
+ffs --source toml --target json -o "$TGT" -m "$MNT" ../toml/single.toml &
 PID=$!
 sleep 2
 umount "$MNT" || fail unmount1    

--- a/tests/touch.sh
+++ b/tests/touch.sh
@@ -15,7 +15,7 @@ fail() {
 MNT=$(mktemp -d)
 ERR=$(mktemp)
 
-ffs --no-output "$MNT" ../json/object.json &
+ffs --no-output -m "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 touch "$MNT"/name 2>$ERR >&2 || { cat "$ERR"; fail touch; }

--- a/tests/truncate.sh
+++ b/tests/truncate.sh
@@ -19,7 +19,7 @@ TGT=$(mktemp)
 TGT2=$(mktemp)
 ERR=$(mktemp)
 
-ffs "$MNT" ../json/object.json >"$TGT" &
+ffs -m "$MNT" ../json/object.json >"$TGT" &
 PID=$!
 sleep 2
 echo 'Mikey Indiana' >"$MNT"/name 2>"$ERR"
@@ -32,7 +32,7 @@ kill -0 $PID >/dev/null 2>&1 && fail process1
 [ -f "$TGT" ] || fail output1
 [ -s "$TGT" ] || fail output2
 grep -e Indiana "$TGT" >/dev/null 2>&1 || fail grep
-ffs --no-output --source json "$MNT" "$TGT" >"$TGT2" &
+ffs --no-output --source json -m "$MNT" "$TGT" >"$TGT2" &
 PID=$!
 sleep 2
 

--- a/tests/unlink.sh
+++ b/tests/unlink.sh
@@ -13,7 +13,7 @@ fail() {
 
 MNT=$(mktemp -d)
 
-ffs "$MNT" ../json/object.json &
+ffs -m "$MNT" ../json/object.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/unpadded_list.sh
+++ b/tests/unpadded_list.sh
@@ -13,7 +13,7 @@ fail() {
 
 MNT=$(mktemp -d)
 
-ffs --unpadded "$MNT" ../json/list2.json &
+ffs --unpadded -m "$MNT" ../json/list2.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/write.sh
+++ b/tests/write.sh
@@ -20,7 +20,7 @@ hi
 hello
 EOF
 
-ffs "$MNT" ../json/list.json &
+ffs -m "$MNT" ../json/list.json &
 PID=$!
 sleep 2
 cd "$MNT"

--- a/tests/yaml_output.sh
+++ b/tests/yaml_output.sh
@@ -20,7 +20,7 @@ YAML="$YAML".yaml
 
 cp ../yaml/invoice.yaml "$YAML"
 
-ffs -i "$MNT" "$YAML" &
+ffs -i -m "$MNT" "$YAML" &
 PID=$!
 sleep 2
 case $(ls "$MNT") in
@@ -35,7 +35,7 @@ umount "$MNT" || fail unmount1
 sleep 1
 kill -0 $PID >/dev/null 2>&1 && fail process1
 
-ffs --readonly --no-output "$MNT" "$YAML" &
+ffs --readonly --no-output -m "$MNT" "$YAML" &
 PID=$!
 sleep 2
 [ "$(cat $MNT/product/0/description)" = "Basketball" ] || fail desc1


### PR DESCRIPTION
Mountpoints are typically inferred/generated from filenames with a `-m`/`--mount` flag for when reading from STDIN or to manually specify a mountpoint.

Addresses #12.