### PR TITLE
fix: wrong mountpoint in fail()

### DIFF
--- a/tests/infer_mount_relative.sh
+++ b/tests/infer_mount_relative.sh
@@ -5,7 +5,7 @@ fail() {
     if [ "$MNT" ]
     then
         cd
-        umount "$TMP"/object
+        umount "$TMP"/nested/object
         rm -r "$TMP"
     fi
     exit 1


### PR DESCRIPTION
`$MNT/nested/object` is the mountpoint, not `$MNT/object`