### PR TITLE
Cleanup

### DIFF
--- a/src/bin/ffs.rs
+++ b/src/bin/ffs.rs
@@ -34,14 +34,14 @@ fn main() {
         Format::Json => {
             let fs: FS<format::json::Value> = FS::new(config);
 
-            info!("mounting on {:?} with options {:?}", mount, options);
+            info!("mounting on {} with options {options:?}", mount.display());
             match fuser::mount2(fs, &mount, &options) {
                 Ok(()) => {
                     info!("unmounted");
                     0
                 }
                 Err(e) => {
-                    error!("I/O error: {}", e);
+                    error!("I/O error: {e}");
                     ERROR_STATUS_FUSE
                 }
             }
@@ -49,14 +49,14 @@ fn main() {
         Format::Toml => {
             let fs: FS<format::toml::Value> = FS::new(config);
 
-            info!("mounting on {:?} with options {:?}", mount, options);
+            info!("mounting on {} with options {options:?}", mount.display());
             match fuser::mount2(fs, &mount, &options) {
                 Ok(()) => {
                     info!("unmounted");
                     0
                 }
                 Err(e) => {
-                    error!("I/O error: {}", e);
+                    error!("I/O error: {e}");
                     ERROR_STATUS_FUSE
                 }
             }
@@ -64,14 +64,14 @@ fn main() {
         Format::Yaml => {
             let fs: FS<format::yaml::Value> = FS::new(config);
 
-            info!("mounting on {:?} with options {:?}", mount, options);
+            info!("mounting on {} with options {options:?}", mount.display());
             match fuser::mount2(fs, &mount, &options) {
                 Ok(()) => {
                     info!("unmounted");
                     0
                 }
                 Err(e) => {
-                    error!("I/O error: {}", e);
+                    error!("I/O error: {e}");
                     ERROR_STATUS_FUSE
                 }
             }
@@ -81,7 +81,7 @@ fn main() {
     if cleanup_mount {
         if mount.exists() {
             if let Err(e) = std::fs::remove_dir(&mount) {
-                warn!("Unable to clean up mountpoint '{}': {}", mount.display(), e);
+                warn!("Unable to clean up mountpoint '{}': {e}", mount.display());
             }
         } else {
             warn!(

--- a/src/bin/unpack.rs
+++ b/src/bin/unpack.rs
@@ -1,5 +1,5 @@
 use fuser::FileType;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 use std::collections::VecDeque;
 use std::fs;
@@ -33,11 +33,11 @@ where
                     .open(&path)?;
 
                 // write `s` into that file
-                f.write(s.as_bytes())?;
+                f.write_all(s.as_bytes())?;
 
                 // set metadata according to `t`
                 if config.allow_xattr {
-                    xattr::set(&path, "user.type", format!("{}", t).as_bytes())?;
+                    xattr::set(&path, "user.type", t.to_string().as_bytes())?;
                 }
             }
             format::Node::Bytes(b) => {
@@ -52,7 +52,7 @@ where
 
                 // set metadata to bytes
                 if config.allow_xattr {
-                    xattr::set(&path, "user.type", format!("{}", Typ::Bytes).as_bytes())?;
+                    xattr::set(&path, "user.type", Typ::Bytes.to_string().as_bytes())?;
                 }
             }
             format::Node::List(vs) => {
@@ -71,9 +71,9 @@ where
                 for (i, child) in vs.into_iter().enumerate() {
                     // TODO(mmg) 2021-06-08 ability to add prefixes
                     let name = if config.pad_element_names {
-                        format!("{:0width$}", i, width = width)
+                        format!("{i:0width$}")
                     } else {
-                        format!("{}", i)
+                        format!("{i}")
                     };
                     let child_path = path.join(name);
 
@@ -108,7 +108,7 @@ where
                             }
                             ffs::config::Munge::Filter => {
                                 // TODO(mmg) 2023-03-06 support logging
-                                warn!("skipping '{}'", field);
+                                warn!("skipping '{field}'");
                                 continue;
                             }
                         }
@@ -135,12 +135,11 @@ where
 
 fn main() -> std::io::Result<()> {
     let config = Config::from_unpack_args();
-    debug!("received config: {:?}", config);
 
     let mount = match &config.mount {
         Some(mount) => mount.clone(),
         None => {
-            error!("Directory not specified");
+            error!("You must specify a directory to unpack.");
             std::process::exit(ERROR_STATUS_CLI);
         }
     };
@@ -154,7 +153,7 @@ fn main() -> std::io::Result<()> {
         }
     };
 
-    let result = match &config.input_format {
+    match &config.input_format {
         Format::Json => {
             let value = JsonValue::from_reader(reader);
             if value.kind() == FileType::Directory {
@@ -182,7 +181,5 @@ fn main() -> std::io::Result<()> {
                 std::process::exit(ERROR_STATUS_FUSE);
             }
         }
-    };
-
-    result
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,7 +133,7 @@ impl Config {
             } else if shell == "zsh" {
                 clap::Shell::Zsh
             } else {
-                eprintln!("Can't generate completions for '{}'.", shell);
+                eprintln!("Can't generate completions for '{shell}'.");
                 std::process::exit(ERROR_STATUS_CLI);
             };
             cli::ffs().gen_completions_to("ffs", shell, &mut std::io::stdout());
@@ -172,7 +172,7 @@ impl Config {
             Some(s) => match str::parse(s) {
                 Ok(munge) => munge,
                 Err(_) => {
-                    warn!("Invalid `--munge` mode '{}', using 'rename'.", s);
+                    warn!("Invalid `--munge` mode '{s}', using 'rename'.");
                     Munge::Rename
                 }
             },
@@ -183,9 +183,8 @@ impl Config {
             Ok(filemode) => filemode,
             Err(e) => {
                 error!(
-                    "Couldn't parse `--mode {}`: {}.",
-                    args.value_of("FILEMODE").unwrap(),
-                    e
+                    "Couldn't parse `--mode {}`: {e}.",
+                    args.value_of("FILEMODE").unwrap()
                 );
                 std::process::exit(ERROR_STATUS_CLI)
             }
@@ -207,9 +206,8 @@ impl Config {
                 Ok(filemode) => filemode,
                 Err(e) => {
                     error!(
-                        "Couldn't parse `--dirmode {}`: {}.",
-                        args.value_of("DIRMODE").unwrap(),
-                        e
+                        "Couldn't parse `--dirmode {}`: {e}.",
+                        args.value_of("DIRMODE").unwrap()
                     );
                     std::process::exit(ERROR_STATUS_CLI)
                 }
@@ -223,8 +221,7 @@ impl Config {
                 Err(e) => {
                     let euid = unsafe { libc::geteuid() };
                     warn!(
-                        "Couldn't parse '{}' as a uid ({}), defaulting to effective uid ({})",
-                        uid_string, e, euid
+                        "Couldn't parse '{uid_string}' as a uid ({e}), defaulting to effective uid ({euid})"
                     );
                     config.uid = euid;
                 }
@@ -237,8 +234,7 @@ impl Config {
                 Err(e) => {
                     let egid = unsafe { libc::getegid() };
                     warn!(
-                        "Couldn't parse '{}' as a gid ({}), defaulting to effective gid ({})",
-                        gid_string, e, egid
+                        "Couldn't parse '{gid_string}' as a gid ({e}), defaulting to effective gid ({egid})"
                     );
                     config.gid = egid;
                 }
@@ -272,8 +268,7 @@ impl Config {
                         match e {
                             format::ParseFormatError::NoSuchFormat(s) => {
                                 warn!(
-                                    "Unrecognized format '{}', inferring from {}.",
-                                    s,
+                                    "Unrecognized format '{s}', inferring from {}.",
                                     output.display(),
                                 )
                             }
@@ -323,10 +318,9 @@ impl Config {
                         }
                         // If the mountpoint can't be created, give up and tell the user about --mount.
                         if let Err(e) = std::fs::create_dir(&mount_dir) {
-                            error!("Couldn't create mountpoint '{}': {}. Use `--mount MOUNT` to specify a mountpoint.",
-                                 mount_dir.display(),
-                                    e
-                                );
+                            error!("Couldn't create mountpoint '{}': {e}. Use `--mount MOUNT` to specify a mountpoint.",
+                                   mount_dir.display(),
+                                  );
                             std::process::exit(ERROR_STATUS_FUSE);
                         }
                         // We did it!
@@ -426,9 +420,8 @@ impl Config {
                                 // If the mountpoint can't be created, give up and tell the user about --mount.
                                 if let Err(e) = std::fs::create_dir(&mount_dir) {
                                     error!(
-                                        "Couldn't create mountpoint '{}': {}. Use `--mount MOUNT` to specify a mountpoint.",
-                                        mount_dir.display(),
-                                        e
+                                        "Couldn't create mountpoint '{}': {e}. Use `--mount MOUNT` to specify a mountpoint.",
+                                        mount_dir.display()
                                     );
                                     std::process::exit(ERROR_STATUS_FUSE);
                                 }
@@ -473,11 +466,15 @@ impl Config {
                                 .and_then(|s| s.parse::<Format>())
                             {
                                 Ok(format) => format,
-                                Err(_) => {
-                                    warn!(
-                                        "Unrecognized format {}, defaulting to JSON.",
-                                        input_source.display()
-                                    );
+                                Err(e) => {
+                                    match e {
+                                        format::ParseFormatError::NoFormatProvided => {
+                                            warn!("No extension detected, defaulting to JSON.")
+                                        }
+                                        format::ParseFormatError::NoSuchFormat(s) => {
+                                            warn!("Unrecognized extension {s}, defaulting to JSON.")
+                                        }
+                                    };
                                     Format::Json
                                 }
                             },
@@ -501,10 +498,7 @@ impl Config {
                     Err(e) => {
                         match e {
                             format::ParseFormatError::NoSuchFormat(s) => {
-                                warn!(
-                                    "Unrecognized format '{}', inferring from input and output.",
-                                    s
-                                )
+                                warn!("Unrecognized format '{s}', inferring from input and output.")
                             }
                             format::ParseFormatError::NoFormatProvided => {
                                 debug!("Inferring output format from input.")
@@ -519,8 +513,8 @@ impl Config {
                                 Ok(format) => format,
                                 Err(_) => {
                                     warn!(
-                                        "Unrecognized format {}, defaulting to input format '{}'.",
-                                        s, config.input_format
+                                        "Unrecognized format {s}, defaulting to input format '{}'.",
+                                        config.input_format
                                     );
                                     config.input_format
                                 }
@@ -560,7 +554,7 @@ impl Config {
             } else if shell == "zsh" {
                 clap::Shell::Zsh
             } else {
-                eprintln!("Can't generate completions for '{}'.", shell);
+                eprintln!("Can't generate completions for '{shell}'.");
                 std::process::exit(ERROR_STATUS_CLI);
             };
             cli::unpack().gen_completions_to("unpack", shell, &mut std::io::stdout());
@@ -597,7 +591,7 @@ impl Config {
             Some(s) => match str::parse(s) {
                 Ok(munge) => munge,
                 Err(_) => {
-                    warn!("Invalid `--munge` mode '{}', using 'rename'.", s);
+                    warn!("Invalid `--munge` mode '{s}', using 'rename'.");
                     Munge::Rename
                 }
             },
@@ -623,7 +617,7 @@ impl Config {
         // infer and create mountpoint from filename as possible
         config.mount = match args.value_of("INTO") {
             Some(mount_point) => {
-                match std::fs::create_dir(&mount_point) {
+                match std::fs::create_dir(mount_point) {
                     Ok(_) => Some(PathBuf::from(mount_point)),
                     Err(_) => {
                         // if dir is empty then we can use it
@@ -633,10 +627,7 @@ impl Config {
                             Some(PathBuf::from(mount_point))
                         } else {
                             // dir exists but is not empty
-                            error!(
-                                "Directory `{}` already exists and is not empty.",
-                                mount_point
-                            );
+                            error!("Directory `{mount_point}` already exists and is not empty.");
                             std::process::exit(ERROR_STATUS_FUSE);
                         }
                     }
@@ -670,9 +661,8 @@ impl Config {
                         // If the mountpoint can't be created, give up and tell the user about --mount.
                         if let Err(e) = std::fs::create_dir(&mount_dir) {
                             error!(
-                                "Couldn't create directory '{}': {}. Use `--into DIRECTORY` to specify a directory.",
-                                mount_dir.display(),
-                                e
+                                "Couldn't create directory '{}': {e}. Use `--into DIRECTORY` to specify a directory.",
+                                mount_dir.display()
                             );
                             std::process::exit(ERROR_STATUS_FUSE);
                         }
@@ -701,7 +691,7 @@ impl Config {
             Err(e) => {
                 match e {
                     format::ParseFormatError::NoSuchFormat(s) => {
-                        warn!("Unrecognized format '{}', inferring from input.", s)
+                        warn!("Unrecognized format '{s}', inferring from input.")
                     }
                     format::ParseFormatError::NoFormatProvided => {
                         debug!("Inferring format from input.")
@@ -750,7 +740,7 @@ impl Config {
             } else if shell == "zsh" {
                 clap::Shell::Zsh
             } else {
-                eprintln!("Can't generate completions for '{}'.", shell);
+                eprintln!("Can't generate completions for '{shell}'.");
                 std::process::exit(ERROR_STATUS_CLI);
             };
             cli::pack().gen_completions_to("pack", shell, &mut std::io::stdout());
@@ -794,10 +784,7 @@ impl Config {
             Some(s) => match str::parse(s) {
                 Ok(depth) => Some(depth),
                 Err(_) => {
-                    error!(
-                        "Invalid `--max-depth` '{}', must be a non-negative integer.",
-                        s
-                    );
+                    error!("Invalid `--max-depth` '{s}', must be a non-negative integer.");
                     std::process::exit(ERROR_STATUS_CLI);
                 }
             },
@@ -810,7 +797,7 @@ impl Config {
             Some(s) => match str::parse(s) {
                 Ok(munge) => munge,
                 Err(_) => {
-                    warn!("Invalid `--munge` mode '{}', using 'rename'.", s);
+                    warn!("Invalid `--munge` mode '{s}', using 'rename'.");
                     Munge::Rename
                 }
             },
@@ -866,10 +853,7 @@ impl Config {
             Err(e) => {
                 match e {
                     format::ParseFormatError::NoSuchFormat(s) => {
-                        warn!(
-                            "Unrecognized format '{}', inferring from input and output.",
-                            s
-                        )
+                        warn!("Unrecognized format '{s}', inferring from input and output.")
                     }
                     format::ParseFormatError::NoFormatProvided => {
                         debug!("Inferring output format from input.")
@@ -884,8 +868,8 @@ impl Config {
                         Ok(format) => format,
                         Err(_) => {
                             warn!(
-                                "Unrecognized format {}, defaulting to input format '{}'.",
-                                s, config.input_format
+                                "Unrecognized format {s}, defaulting to input format '{}'.",
+                                config.input_format
                             );
                             config.input_format
                         }
@@ -915,7 +899,7 @@ impl Config {
         } else if s == ".." {
             "_..".into()
         } else {
-            s.replace("\0", "_NUL_").replace("/", "_SLASH_")
+            s.replace('\0', "_NUL_").replace('/', "_SLASH_")
         }
     }
 
@@ -956,8 +940,8 @@ impl Config {
             Input::Stdin => Some(Box::new(std::io::stdin())),
             Input::File(file) => {
                 let fmt = self.input_format;
-                let file = std::fs::File::open(&file).unwrap_or_else(|e| {
-                    error!("Unable to open {} for {} input: {}", file.display(), fmt, e);
+                let file = std::fs::File::open(file).unwrap_or_else(|e| {
+                    error!("Unable to open {} for {fmt} input: {e}", file.display());
                     std::process::exit(ERROR_STATUS_FUSE);
                 });
                 Some(Box::new(file))

--- a/src/format.rs
+++ b/src/format.rs
@@ -18,9 +18,9 @@ macro_rules! time_ns {
         let msg = $msg;
         let elapsed = start.elapsed().as_nanos();
         if $timing {
-            eprintln!("{},{}", msg, elapsed);
+            eprintln!("{msg},{elapsed}");
         } else {
-            info!("{} ({}ns)", msg, elapsed);
+            info!("{msg} ({elapsed}ns)");
         }
         v
     }};
@@ -226,8 +226,8 @@ pub mod json {
 
             match self {
                 Value::Null => Node::String(Typ::Null, "".into()), // always empty
-                Value::Bool(b) => Node::String(Typ::Boolean, format!("{}{}", b, nl)),
-                Value::Number(n) => Node::String(Typ::Float, format!("{}{}", n, nl)),
+                Value::Bool(b) => Node::String(Typ::Boolean, format!("{b}{nl}")),
+                Value::Number(n) => Node::String(Typ::Float, format!("{n}{nl}")),
                 Value::String(s) => {
                     if config.try_decode_base64 {
                         if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(&s) {
@@ -263,7 +263,7 @@ pub mod json {
                     } else if contents == "false" {
                         Value::Bool(false)
                     } else {
-                        debug!("string '{}' tagged as boolean", contents);
+                        debug!("string '{contents}' tagged as boolean");
                         Value::String(contents)
                     }
                 }
@@ -273,7 +273,7 @@ pub mod json {
                     if let Ok(n) = serde_json::Number::from_str(&contents) {
                         Value::Number(n)
                     } else {
-                        debug!("string '{}' tagged as float", contents);
+                        debug!("string '{contents}' tagged as float");
                         Value::String(contents)
                     }
                 }
@@ -281,7 +281,7 @@ pub mod json {
                     if let Ok(n) = serde_json::Number::from_str(&contents) {
                         Value::Number(n)
                     } else {
-                        debug!("string '{}' tagged as float", contents);
+                        debug!("string '{contents}' tagged as float");
                         Value::String(contents)
                     }
                 }
@@ -289,7 +289,7 @@ pub mod json {
                     if contents.is_empty() {
                         Value::Null
                     } else {
-                        debug!("string '{}' tagged as null", contents);
+                        debug!("string '{contents}' tagged as null");
                         Value::String(contents)
                     }
                 }
@@ -354,7 +354,7 @@ pub mod toml {
             | Toml::Float(_)
             | Toml::Integer(_)
             | Toml::String(_) => 1,
-            Toml::Array(vs) => vs.iter().map(|v| toml_size(v)).sum::<usize>() + 1,
+            Toml::Array(vs) => vs.iter().map(toml_size).sum::<usize>() + 1,
             Toml::Table(fvs) => fvs.iter().map(|(_, v)| toml_size(v)).sum::<usize>() + 1,
         }
     }
@@ -375,10 +375,10 @@ pub mod toml {
             let nl = if config.add_newlines { "\n" } else { "" };
 
             match self.0 {
-                Toml::Boolean(b) => Node::String(Typ::Boolean, format!("{}{}", b, nl)),
+                Toml::Boolean(b) => Node::String(Typ::Boolean, format!("{b}{nl}")),
                 Toml::Datetime(s) => Node::String(Typ::Datetime, s.to_string()),
-                Toml::Float(n) => Node::String(Typ::Float, format!("{}{}", n, nl)),
-                Toml::Integer(n) => Node::String(Typ::Integer, format!("{}{}", n, nl)),
+                Toml::Float(n) => Node::String(Typ::Float, format!("{n}{nl}")),
+                Toml::Integer(n) => Node::String(Typ::Integer, format!("{n}{nl}")),
                 Toml::String(s) => {
                     if config.try_decode_base64 {
                         if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(&s) {
@@ -418,7 +418,7 @@ pub mod toml {
                     } else if contents == "false" {
                         Toml::Boolean(false)
                     } else {
-                        debug!("string '{}' tagged as boolean", contents);
+                        debug!("string '{contents}' tagged as boolean");
                         Toml::String(contents)
                     }
                 }
@@ -426,10 +426,7 @@ pub mod toml {
                 Typ::Datetime => match str::parse(&contents) {
                     Ok(datetime) => Toml::Datetime(datetime),
                     Err(e) => {
-                        debug!(
-                            "string '{}' tagged as datetime, didn't parse: {}",
-                            contents, e
-                        );
+                        debug!("string '{contents}' tagged as datetime, didn't parse: {e}");
                         Toml::String(contents)
                     }
                 },
@@ -437,7 +434,7 @@ pub mod toml {
                     if let Ok(n) = f64::from_str(&contents) {
                         Toml::Float(n)
                     } else {
-                        debug!("string '{}' tagged as float", contents);
+                        debug!("string '{contents}' tagged as float");
                         Toml::String(contents)
                     }
                 }
@@ -445,7 +442,7 @@ pub mod toml {
                     if let Ok(n) = i64::from_str(&contents) {
                         Toml::Integer(n)
                     } else {
-                        debug!("string '{}' tagged as float", contents);
+                        debug!("string '{contents}' tagged as float");
                         Toml::String(contents)
                     }
                 }
@@ -453,7 +450,7 @@ pub mod toml {
                     if contents.is_empty() {
                         Toml::String(contents)
                     } else {
-                        debug!("string '{}' tagged as null", contents);
+                        debug!("string '{contents}' tagged as null");
                         Toml::String(contents)
                     }
                 }
@@ -537,18 +534,18 @@ pub mod yaml {
             | Yaml::Null
             | Yaml::BadValue
             | Yaml::Alias(_) => 1,
-            Yaml::Array(vs) => vs.iter().map(|v| yaml_size(v)).sum::<usize>() + 1,
+            Yaml::Array(vs) => vs.iter().map(yaml_size).sum::<usize>() + 1,
             Yaml::Hash(fvs) => fvs.iter().map(|(_, v)| yaml_size(v)).sum::<usize>() + 1,
         }
     }
 
     fn yaml_key_to_string(v: Yaml) -> String {
         match v {
-            Yaml::Boolean(b) => format!("{}", b),
+            Yaml::Boolean(b) => format!("{b}"),
             Yaml::Real(s) => s,
-            Yaml::Integer(n) => format!("{}", n),
+            Yaml::Integer(n) => format!("{n}"),
             Yaml::String(s) => s,
-            Yaml::Alias(n) => format!("alias{}", n),
+            Yaml::Alias(n) => format!("alias{n}"),
             Yaml::Array(vs) => {
                 let mut hasher = std::collections::hash_map::DefaultHasher::new();
                 vs.hash(&mut hasher);
@@ -581,9 +578,9 @@ pub mod yaml {
 
             match self.0 {
                 Yaml::Null => Node::String(Typ::Null, "".into()),
-                Yaml::Boolean(b) => Node::String(Typ::Boolean, format!("{}{}", b, nl)),
+                Yaml::Boolean(b) => Node::String(Typ::Boolean, format!("{b}{nl}")),
                 Yaml::Real(s) => Node::String(Typ::Float, s + nl),
-                Yaml::Integer(n) => Node::String(Typ::Integer, format!("{}{}", n, nl)),
+                Yaml::Integer(n) => Node::String(Typ::Integer, format!("{n}{nl}")),
                 Yaml::String(s) => {
                     if config.try_decode_base64 {
                         if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(&s) {
@@ -600,7 +597,7 @@ pub mod yaml {
                         .collect(),
                 ),
                 // ??? 2021-06-21 support aliases w/hard links?
-                Yaml::Alias(n) => Node::Bytes(format!("alias{}{}", n, nl).into_bytes()),
+                Yaml::Alias(n) => Node::Bytes(format!("alias{n}{nl}").into_bytes()),
                 Yaml::BadValue => Node::Bytes("bad YAML value".into()),
             }
         }
@@ -628,7 +625,7 @@ pub mod yaml {
                     } else if contents == "false" {
                         Value(Yaml::Boolean(false))
                     } else {
-                        debug!("string '{}' tagged as boolean", contents);
+                        debug!("string '{contents}' tagged as boolean");
                         Value(Yaml::String(contents))
                     }
                 }
@@ -638,7 +635,7 @@ pub mod yaml {
                     if let Ok(_n) = f64::from_str(&contents) {
                         Value(Yaml::Real(contents))
                     } else {
-                        debug!("string '{}' tagged as float", contents);
+                        debug!("string '{contents}' tagged as float");
                         Value(Yaml::String(contents))
                     }
                 }
@@ -646,7 +643,7 @@ pub mod yaml {
                     if let Ok(n) = i64::from_str(&contents) {
                         Value(Yaml::Integer(n))
                     } else {
-                        debug!("string '{}' tagged as float", contents);
+                        debug!("string '{contents}' tagged as float");
                         Value(Yaml::String(contents))
                     }
                 }
@@ -654,7 +651,7 @@ pub mod yaml {
                     if contents.is_empty() {
                         Value(Yaml::Null)
                     } else {
-                        debug!("string '{}' tagged as null", contents);
+                        debug!("string '{contents}' tagged as null");
                         Value(Yaml::String(contents))
                     }
                 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -167,9 +167,9 @@ where
                 for (i, child) in vs.into_iter().enumerate() {
                     // TODO 2021-06-08 ability to add prefixes
                     let name = if self.config.pad_element_names {
-                        format!("{:0width$}", i, width = width)
+                        format!("{i:0width$}")
                     } else {
-                        format!("{}", i)
+                        format!("{i}")
                     };
 
                     let kind = child.kind();
@@ -216,7 +216,7 @@ where
                                 nfield
                             }
                             Munge::Filter => {
-                                warn!("skipping '{}'", field);
+                                warn!("skipping '{field}'");
                                 continue;
                             }
                         }
@@ -234,8 +234,7 @@ where
                     );
                     let original_name = if original != nfield {
                         info!(
-                            "renamed {} to {} (inode {} with parent {})",
-                            original, nfield, child_id, inum
+                            "renamed {original} to {nfield} (inode {child_id} with parent {inum})"
                         );
                         Some(original)
                     } else {
@@ -281,8 +280,7 @@ where
             None => return Ok(()),
         };
 
-        while !worklist.is_empty() {
-            let node = worklist.pop().unwrap();
+        while let Some(node) = worklist.pop() {
             if let Some(nodes) = self.resolve_node(node)? {
                 worklist.extend(nodes);
             }
@@ -353,7 +351,7 @@ where
 
         let v = time_ns!("reading", V::from_reader(reader), config.timing);
         if v.kind() != FileType::Directory {
-            error!("The root of the filesystem must be a directory, but '{}' only generates a single file.", v);
+            error!("The root of the filesystem must be a directory, but '{v}' only generates a single file.");
             std::process::exit(ERROR_STATUS_FUSE);
         }
 
@@ -513,7 +511,7 @@ where
                 files.sort_unstable_by(|(name1, _), (name2, _)| name1.cmp(name2));
                 for (name, DirEntry { inum, .. }) in files.iter() {
                     if self.config.ignored_file(name) {
-                        warn!("skipping ignored file '{}'", name);
+                        warn!("skipping ignored file '{name}'");
                         continue;
                     }
                     let v = self.as_value(*inum);
@@ -533,7 +531,7 @@ where
                 ) in files.iter()
                 {
                     if self.config.ignored_file(name) {
-                        warn!("skipping ignored file '{}'", name);
+                        warn!("skipping ignored file '{name}'");
                         continue;
                     }
                     let v = self.as_value(*inum);
@@ -577,7 +575,7 @@ where
                 files.sort_unstable_by(|(name1, _), (name2, _)| name1.cmp(name2));
                 for (name, inum) in files {
                     if self.config.ignored_file(&name) {
-                        warn!("skipping ignored file '{}'", name);
+                        warn!("skipping ignored file '{name}'");
                         continue;
                     }
                     let v = self.as_other_value(inum);
@@ -594,7 +592,7 @@ where
                     .collect::<Vec<_>>();
                 for (name, inum, original_name) in files.iter() {
                     if self.config.ignored_file(name) {
-                        warn!("skipping ignored file '{}'", name);
+                        warn!("skipping ignored file '{name}'");
                         continue;
                     }
                     let v = self.as_other_value(*inum);
@@ -1001,7 +999,7 @@ where
         }
 
         if let Some(size) = size {
-            info!("truncate() to {}", size);
+            info!("truncate() to {size}");
 
             match self.get_mut(ino) {
                 Ok(inode) => match &mut inode.entry {
@@ -1286,7 +1284,6 @@ where
                 for (i, entry) in dot_entries
                     .into_iter()
                     .chain(entries)
-                    .into_iter()
                     .enumerate()
                     .skip(offset as usize)
                 {
@@ -1337,8 +1334,8 @@ where
         }
 
         // make sure we have a good file type
-        let file_type = mode & libc::S_IFMT as u32;
-        if !vec![libc::S_IFREG as u32, libc::S_IFDIR as u32].contains(&file_type) {
+        let file_type = mode & libc::S_IFMT;
+        if ![libc::S_IFREG, libc::S_IFDIR].contains(&file_type) {
             warn!(
                 "mknod only supports regular files and directories; got {:o}",
                 mode
@@ -1378,10 +1375,10 @@ where
         };
 
         // create the inode entry
-        let (entry, kind) = if file_type == libc::S_IFREG as u32 {
+        let (entry, kind) = if file_type == libc::S_IFREG {
             (Entry::File(Typ::Auto, Vec::new()), FileType::RegularFile)
         } else {
-            assert_eq!(file_type, libc::S_IFDIR as u32);
+            assert_eq!(file_type, { libc::S_IFDIR });
             (
                 Entry::Directory(DirType::Named, BTreeMap::new()),
                 FileType::Directory,
@@ -1894,7 +1891,7 @@ where
         };
 
         // extend the vector
-        let extra_bytes = (offset + length as i64) - contents.len() as i64;
+        let extra_bytes = (offset + length) - contents.len() as i64;
         if extra_bytes > 0 {
             contents.resize(contents.len() + extra_bytes as usize, 0);
         }


### PR DESCRIPTION
Satisfy clippy. Improve format strings to use `format!("{foo}")` instead of `format!("{}", foo)` when possible. General formatting.